### PR TITLE
Returning empty string from either assertPath or publicUrl allows to skip that asset from download

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ If `assetPath` is a function, it will be invoked for each asset detected with tw
 - `entry` (Object): The entry in which the asset was detected
 - `asset` (Object): The normalized asset object
 
-Its return value will be used as the path for the asset.
+Its return value will be used as the path for the asset. If its return empty string then the asset is skipped from donwload.
 
 ### `publicUrl`
 
@@ -55,7 +55,7 @@ If `publicUrl` is a function, it will be invoked for each asset detected with tw
 - `asset` (Object): The normalized asset object
 - `assetPath` (String): The local path where the asset has been saved
 
-Its return value will replace the original URL of the asset in any objects.
+Its return value will replace the original URL of the asset in any objects. If its return empty string then the asset is skipped from donwload.
 
 ### 👀 Example configuration
 

--- a/index.js
+++ b/index.js
@@ -37,7 +37,11 @@ module.exports.transform = async ({ data, debug, log, options }) => {
         ? options.publicUrl(null, entry, assetPath)
         : options.publicUrl;
 
-    result.set(regExp, { assetPath, publicUrl });
+
+    if (assetPath && publicUrl) {
+      debug("Found asset %s, %s", assetPath, publicUrl);
+      result.set(regExp, { assetPath, publicUrl });
+    }
 
     return result;
   }, new Map());
@@ -62,8 +66,10 @@ module.exports.transform = async ({ data, debug, log, options }) => {
             ? options.publicUrl(entry, value, assetPath)
             : options.publicUrl;
 
-        filesToDownload[value.url] = path.join(process.cwd(), assetPath);
-        replacedFields[fieldName] = publicUrl;
+        if (assetPath && publicUrl) {
+          filesToDownload[value.url] = path.join(process.cwd(), assetPath);
+          replacedFields[fieldName] = publicUrl;
+        }
       } else if (typeof entry[fieldName] === "string") {
         assets.forEach(({ assetPath, publicUrl }, expression) => {
           let isMatch = false;


### PR DESCRIPTION
I recently found a use-case when I wanted to select assets to download from the Contentful assets, and I did not found other natural ways to achieve this behavior, so I added this little patch. I hope you find it useful to merge or let me know what should the better way to handle the situation.